### PR TITLE
ESP32-P4 PARLIO: fix WS2812 bit order, brightness, double-gamma; raise LED cap

### DIFF
--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -706,7 +706,7 @@ BusParallelIO::BusParallelIO(BusConfig& bc, const ColorOrderMap& com) : Bus(bc.t
   memcpy(_pins, bc.pins, sizeof(_pins));
   _outputs = bc.outputs;
   _leds_per_output = bc.leds_per_output;
-  _gammacorrect = true;
+  _gammacorrect = false; // WLED already gamma-corrects colours upstream (gamma32); re-applying here double-corrects and crushes the low end to black. Driver does brightness only, like the other digital buses.
   for (uint8_t i = 0; i < _outputs; i++) {
     if (!pinManager.allocatePin(_pins[i], true, PinOwner::Parallel_IO)){
       USER_PRINTF("Error owning GPIO %d\n", _pins[i]);

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -453,14 +453,14 @@
 
           if (isPar) {
             d.getElementsByName("AO" + n)[0].max = d.max_parlio;
-            d.getElementsByName("AL" + n)[0].value = Math.min(Number(d.getElementsByName("AL" + n)[0].value), 1024);
+            d.getElementsByName("AL" + n)[0].value = Math.min(Number(d.getElementsByName("AL" + n)[0].value), 2048);
             d.getElementsByName("SL" + n)[0].style.display = "none";
             d.getElementsByName("CV" + n)[0].style.display = "none";
             d.getElementsByName("RF" + n)[0].style.display = "none"; // coimment out if Parallel IO needs off-refresh
           }
           d.getElementsByName("AO" + n)[0].min = (isNet || isPar) ? 1 : -1;
           d.getElementsByName("AL" + n)[0].min = (isNet || isPar) ? 1 : -1;
-          if (isPar) d.getElementsByName("AL" + n)[0].max = Number(1024);
+          if (isPar) d.getElementsByName("AL" + n)[0].max = Number(2048);
           if (isNet) d.getElementsByName("AL" + n)[0].max = Number(maxL);
           d.getElementsByName("AF" + n)[0].min = (isNet) ? 1 : -1;
 

--- a/wled00/parlio.cpp
+++ b/wled00/parlio.cpp
@@ -145,11 +145,17 @@ void create_transposed_led_output_optimized(
 
   if (bri != last_bri || gammacorrect != last_gammacorrect) {
     for (int i = 0; i < 256; ++i) {
-      brightness_cache[i] = gammacorrect ? (gamma8(i) * bri) >> 8 : (i * bri) >> 8;
+      brightness_cache[i] = gammacorrect ? (gamma8(i) * bri) / 255 : (i * bri) / 255; // /255 (not >>8) so full brightness is an exact passthrough
     }
     for (int i = 0; i < 256; ++i) {
-      const uint16_t p1 = bitpatterns[i >> 4];
-      const uint16_t p2 = bitpatterns[i & 0x0F];
+      // The transpose + PARLIO packing emits each byte's bit-codes in a nibble-pair
+      // swapped order (bit0<->2, 1<->3, 4<->6, 5<->7) -- verified on a scope by walking
+      // single-bit values (only 0x00 and 0xFF survived unchanged, the fingerprint of a
+      // bit shuffle). Pre-swapping the lookup index (the swap is its own inverse) cancels
+      // it, so the value on the wire matches what WLED requested.
+      const uint8_t s = ((i & 0x33) << 2) | ((i & 0xCC) >> 2);
+      const uint16_t p1 = bitpatterns[s >> 4];
+      const uint16_t p2 = bitpatterns[s & 0x0F];
       waveform_cache[i] = (uint32_t(p2) << 16) | p1;
     }
     last_bri = bri;
@@ -308,12 +314,12 @@ uint8_t IRAM_ATTR __attribute__((hot)) show_parlio(uint8_t* parallelPins, uint32
 
   static byte* parallel_buffer_remapped = NULL;
 #ifdef WLEDMM_REMAP_AT_OUTPUT
-  static byte* parallel_buffer_remapped1 = (byte*)heap_caps_calloc_prefer((1024 * 16 * 4) + 15, sizeof(byte), 2, MALLOC_CAP_SPIRAM | MALLOC_CAP_DMA, MALLOC_CAP_DMA);
-  static byte* parallel_buffer_remapped2 = (byte*)heap_caps_calloc_prefer((1024 * 16 * 4) + 15, sizeof(byte), 2, MALLOC_CAP_SPIRAM | MALLOC_CAP_DMA, MALLOC_CAP_DMA);
+  static byte* parallel_buffer_remapped1 = (byte*)heap_caps_calloc_prefer((2048 * 16 * 4) + 15, sizeof(byte), 2, MALLOC_CAP_SPIRAM | MALLOC_CAP_DMA, MALLOC_CAP_DMA);
+  static byte* parallel_buffer_remapped2 = (byte*)heap_caps_calloc_prefer((2048 * 16 * 4) + 15, sizeof(byte), 2, MALLOC_CAP_SPIRAM | MALLOC_CAP_DMA, MALLOC_CAP_DMA);
 #endif 
   static uint16_t* parallel_buffer_repacked = NULL;
-  static uint16_t* parallel_buffer_repacked1 = (uint16_t*)heap_caps_calloc_prefer((1024 * 16 * 16), 1, 2, MALLOC_CAP_SPIRAM | MALLOC_CAP_DMA | MALLOC_CAP_CACHE_ALIGNED, MALLOC_CAP_DMA);
-  static uint16_t* parallel_buffer_repacked2 = (uint16_t*)heap_caps_calloc_prefer((1024 * 16 * 16), 1, 2, MALLOC_CAP_SPIRAM | MALLOC_CAP_DMA | MALLOC_CAP_CACHE_ALIGNED, MALLOC_CAP_DMA);
+  static uint16_t* parallel_buffer_repacked1 = (uint16_t*)heap_caps_calloc_prefer((2048 * 16 * 16), 1, 2, MALLOC_CAP_SPIRAM | MALLOC_CAP_DMA | MALLOC_CAP_CACHE_ALIGNED, MALLOC_CAP_DMA);
+  static uint16_t* parallel_buffer_repacked2 = (uint16_t*)heap_caps_calloc_prefer((2048 * 16 * 16), 1, 2, MALLOC_CAP_SPIRAM | MALLOC_CAP_DMA | MALLOC_CAP_CACHE_ALIGNED, MALLOC_CAP_DMA);
 
   if (parallel_buffer_repacked == NULL) parallel_buffer_repacked = parallel_buffer_repacked1;
 #ifdef WLEDMM_REMAP_AT_OUTPUT


### PR DESCRIPTION
## ESP32-P4 PARLIO WS2812 output fixes

Found while bringing up a ~1070-LED WS2812 strip on the P4 PARLIO driver, and verified with an oscilloscope. Four independent fixes — happy to split into separate PRs or drop any if you'd prefer.

### 1. Bit order (correctness) — the important one
Each byte's WS2812 bit-codes were emitted in a **nibble-pair-swapped** order (bit0↔2, 1↔3, 4↔6, 5↔7), so the value clocked onto the wire never matched the requested value. Only `0x00` and `0xFF` came out correct — the classic fingerprint of a bit shuffle (the only two bytes invariant under any bit permutation). Mapped exactly with a single-bit scope walk on the green channel, then fixed by pre-swapping the `waveform_cache` lookup index (the swap is its own inverse, so it cancels). The encoding is data-width-independent, so the fix applies to all output counts.

### 2. Brightness scaling
`brightness_cache[i] = (i * bri) >> 8` divides by 256, so even at `bri = 255` everything was scaled to 255/256 (`0xFF` → `0xFE`). Changed to `/255` for an exact passthrough at full brightness. It's computed once per brightness change, so the divide isn't on the hot path.

### 3. Double gamma correction
`BusParallelIO` was constructed with `_gammacorrect = true` and re-applied gamma in the driver, on top of WLED's upstream `gamma32()`. Two stacked gamma curves crushed the low end to black below ~30% and made brightness non-monotonic. Set to `false` so the bus does brightness only and WLED owns the single gamma pass — consistent with the other digital buses (HUB75 already calls `unGamma24()` for the same reason).

### 4. Per-output LED cap
The DMA buffers were hardcoded to 1024 LEDs/output and the LED-settings UI clamped "LEDs per output" to 1024 — longer strips overflowed / were silently truncated. Raised to 2048 (firmware buffers in `parlio.cpp` + `settings_leds.htm`).

---
Thanks for the P4 work — it's what made this possible.
